### PR TITLE
Fix the multiline padded background on Firefox

### DIFF
--- a/src/components/Album.vue
+++ b/src/components/Album.vue
@@ -226,6 +226,9 @@ export default {
       color: #000;
       background: #fff;
       box-shadow: -15px 0 0 0 #fff, 15px 0 0 0 #fff;
+      // https://www.w3.org/TR/css-backgrounds-3/#the-box-decoration-break  
+      box-decoration-break: clone;
+      -webkit-box-decoration-break: clone;
       @include ipad {
         font-size: 0.8rem;
         line-height: 2rem;


### PR DESCRIPTION
Before:
<img width="537" alt="Screenshot 2020-02-17 at 11 43 25" src="https://user-images.githubusercontent.com/1534688/74651990-5a8e5900-5185-11ea-87f6-c36d2a72e605.png">

After:
<img width="542" alt="Screenshot 2020-02-17 at 13 00 20" src="https://user-images.githubusercontent.com/1534688/74652048-7e519f00-5185-11ea-8288-1ab2243d33a5.png">
